### PR TITLE
Troubleshoot Docker build failure

### DIFF
--- a/auth-app/backend/go.mod
+++ b/auth-app/backend/go.mod
@@ -1,6 +1,8 @@
 module auth-backend
 
-go 1.23
+go 1.23.0
+
+toolchain go1.24.2
 
 require (
 	github.com/gin-contrib/cors v1.7.6


### PR DESCRIPTION
Update go.mod to resolve `go mod tidy` error during Docker build.